### PR TITLE
Need SelfHeal disabled

### DIFF
--- a/roles/ocp4_workload_app_connectivity_workshop/templates/travel_agency.yaml.j2
+++ b/roles/ocp4_workload_app_connectivity_workshop/templates/travel_agency.yaml.j2
@@ -14,9 +14,9 @@ spec:
   syncPolicy:
     automated:
       prune: true
-      selfHeal: true
+      selfHeal: false
     syncOptions:
-      - ApplyOutOfSyncOnly=true
+      - ApplyOutOfSyncOnly=false
       - CreateNamespace=true
   source:
     repoURL: {{ ocp4_workload_app_connectivity_workshop_gitops_repo }}


### PR DESCRIPTION
I just need self-healing disabled for the `travel-agency` namespace, as students will modify it during m2.